### PR TITLE
[IDLE-242] 리뷰, feignClient 버그 수정 및 블루그린 배포 설정

### DIFF
--- a/.github/workflows/book-service-ecr-ecs.yml
+++ b/.github/workflows/book-service-ecr-ecs.yml
@@ -74,3 +74,21 @@ jobs:
           docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: bookService
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: bookService-EcsService
+          cluster: MybraryCluster
+          codedeploy-deployment-group: DgpECS-MybraryCluster-bookService-EcsService
+          codedeploy-appspec: appspec.yaml
+          wait-for-service-stability: true

--- a/book-service/Dockerfile
+++ b/book-service/Dockerfile
@@ -1,8 +1,4 @@
 FROM openjdk:21-ea-17-jdk-slim
 COPY build/libs/book-service-0.0.1-SNAPSHOT.jar book-service.jar
 
-RUN apt update && apt install curl -y && apt install jq -y
-COPY entrypoint.sh /usr/local/bin/
-
-RUN chmod +x /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["java", "-jar", "book-service.jar"]

--- a/book-service/appspec.yaml
+++ b/book-service/appspec.yaml
@@ -1,0 +1,10 @@
+version: 0.0
+Resources:
+  - TargetService:
+      Type: AWS::ECS::Service
+      Properties:
+        TaskDefinition: taskDefinition
+        LoadBalancerInfo:
+          ContainerName: bookService	
+          ContainerPort: 80
+        PlatformVersion: "LATEST"

--- a/book-service/entrypoint.sh
+++ b/book-service/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-response=$(curl -s ${ECS_CONTAINER_METADATA_URI_V4})
-export ECS_INSTANCE_IP_ADDRESS=$(echo $response | jq -r '.Networks[0].IPv4Addresses[0]')
-echo $ECS_INSTANCE_IP_ADDRESS
-
-java -jar book-service.jar

--- a/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/book/persistence/Book.java
@@ -125,11 +125,11 @@ public class Book extends BaseEntity {
         this.interestCount--;
     }
 
-    private void increaseReadCount() {
+    public void increaseReadCount() {
         this.readCount++;
     }
 
-    private void decreaseReadCount() {
+    public void decreaseReadCount() {
         this.readCount--;
     }
 

--- a/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
@@ -11,7 +11,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "user-service")
+@FeignClient(url = "${mybrary.user-service.url}")
 public interface UserServiceClient {
 
     String DEFAULT_PROFILE_IMAGE_URL = "https://mybrary-user-service-resized.s3.ap-northeast-2.amazonaws.com/tiny-profile/profileImage/default.jpg";

--- a/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
@@ -11,7 +11,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(url = "${mybrary.user-service.url}")
+@FeignClient(name = "userClient")
 public interface UserServiceClient {
 
     String DEFAULT_PROFILE_IMAGE_URL = "https://mybrary-user-service-resized.s3.ap-northeast-2.amazonaws.com/tiny-profile/profileImage/default.jpg";

--- a/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookWriteService.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/mybook/domain/MyBookWriteService.java
@@ -44,7 +44,7 @@ public class MyBookWriteService {
         }
 
         myBook.getBook().decreaseHolderCount();
-        myBook.deleteMyBook();
+        myBookRepository.delete(myBook);
     }
 
     public MyBookUpdateResponse updateMyBookProperties(MybookUpdateServiceRequest request) {

--- a/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/MyBook.java
@@ -1,5 +1,6 @@
 package kr.mybrary.bookservice.mybook.persistence;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -19,6 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 @Entity
@@ -27,13 +29,14 @@ import org.hibernate.annotations.Where;
 @AllArgsConstructor
 @NoArgsConstructor
 @Where(clause = "deleted = false")
+@SQLDelete(sql = "UPDATE my_book SET deleted = true WHERE id = ?")
 public class MyBook extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String userId; // TODO: 타입 미정
+    private String userId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Book book;
@@ -44,7 +47,7 @@ public class MyBook extends BaseEntity {
     @OneToOne(mappedBy = "myBook", fetch = FetchType.LAZY)
     private MyBookMeaningTag myBookMeaningTag;
 
-    @OneToOne(mappedBy = "myBook", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "myBook", fetch = FetchType.LAZY, orphanRemoval = true, cascade = CascadeType.REMOVE)
     private MyReview myReview;
 
     private LocalDateTime startDateOfPossession;
@@ -70,10 +73,6 @@ public class MyBook extends BaseEntity {
 
     public boolean isPrivate() {
         return !this.showable;
-    }
-
-    public void deleteMyBook() {
-        this.deleted = true;
     }
 
     public void updateFromUpdateRequest(MybookUpdateServiceRequest updateRequest) {

--- a/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepositoryCustom.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepositoryCustom.java
@@ -2,7 +2,9 @@ package kr.mybrary.bookservice.mybook.persistence.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import kr.mybrary.bookservice.book.persistence.Book;
+import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import kr.mybrary.bookservice.mybook.persistence.MyBookOrderType;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import kr.mybrary.bookservice.mybook.persistence.model.MyBookListDisplayElementModel;
@@ -17,4 +19,5 @@ public interface MyBookRepositoryCustom {
 
     List<String> getMyBookUserIdListByBook(Book book);
 
+    Optional<MyBook> getMyBookWithBookAndReviewUsingFetchJoin(Long mybookId);
 }

--- a/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepositoryCustomImpl.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/mybook/persistence/repository/MyBookRepositoryCustomImpl.java
@@ -12,8 +12,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import kr.mybrary.bookservice.book.persistence.Book;
 import kr.mybrary.bookservice.book.persistence.bookInfo.BookAuthor;
+import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import kr.mybrary.bookservice.mybook.persistence.MyBookOrderType;
 import kr.mybrary.bookservice.mybook.persistence.ReadStatus;
 import kr.mybrary.bookservice.mybook.persistence.model.MyBookListDisplayElementModel;
@@ -92,6 +94,16 @@ public class MyBookRepositoryCustomImpl implements MyBookRepositoryCustom {
                 .where(myBook.book.eq(book),
                         myBook.showable.eq(true))
                 .fetch();
+    }
+
+    @Override
+    public Optional<MyBook> getMyBookWithBookAndReviewUsingFetchJoin(Long mybookId) {
+        return Optional.ofNullable(queryFactory.select(myBook)
+                .from(myBook)
+                .join(myBook.book).fetchJoin()
+                .leftJoin(myBook.myReview).fetchJoin()
+                .where(myBook.id.eq(mybookId))
+                .fetchOne());
     }
 
     private BooleanExpression eqReadStatus(ReadStatus readStatus) {

--- a/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewWriteService.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/review/domain/MyReviewWriteService.java
@@ -56,7 +56,7 @@ public class MyReviewWriteService {
         checkIsOwnerSameAsRequester(myReview.getMyBook().getUserId(), request.getLoginId());
 
         removeBookReviewCountAndStarRating(myReview.getBook(), myReview.getStarRating());
-        myReview.delete();
+        myReviewRepository.delete(myReview);
     }
 
     private MyReview getMyReviewById(Long myReviewId) {
@@ -84,7 +84,7 @@ public class MyReviewWriteService {
         book.updateWhenUpdateReview(originStarRating, newStarRating);
     }
 
-    private static void removeBookReviewCountAndStarRating(Book book, Double originStarRating) {
+    private void removeBookReviewCountAndStarRating(Book book, Double originStarRating) {
         book.updateWhenDeleteReview(originStarRating);
     }
 }

--- a/book-service/src/main/java/kr/mybrary/bookservice/review/persistence/MyReview.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/review/persistence/MyReview.java
@@ -17,6 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 @Entity
@@ -25,6 +26,7 @@ import org.hibernate.annotations.Where;
 @AllArgsConstructor
 @NoArgsConstructor
 @Where(clause = "deleted = false")
+@SQLDelete(sql = "UPDATE my_review SET deleted = true WHERE id = ?")
 public class MyReview extends BaseEntity {
 
     @Id

--- a/book-service/src/main/java/kr/mybrary/bookservice/review/persistence/MyReview.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/review/persistence/MyReview.java
@@ -17,16 +17,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Where(clause = "deleted = false")
-@SQLDelete(sql = "UPDATE my_review SET deleted = true WHERE id = ?")
 public class MyReview extends BaseEntity {
 
     @Id
@@ -43,7 +39,6 @@ public class MyReview extends BaseEntity {
     private String content;
 
     private Double starRating;
-    private boolean deleted;
 
     public static MyReview of(MyBook myBook, MyReviewCreateServiceRequest request) {
         return MyReview.builder()
@@ -57,9 +52,5 @@ public class MyReview extends BaseEntity {
     public void update (MyReviewUpdateServiceRequest request) {
         this.content = request.getContent();
         this.starRating = request.getStarRating();
-    }
-
-    public void delete() {
-        this.deleted = true;
     }
 }

--- a/book-service/src/main/resources/application-test.yml
+++ b/book-service/src/main/resources/application-test.yml
@@ -39,7 +39,7 @@ eureka:
 
 logging:
   level:
-    root: debug
+    root: info
     org:
       hibernate:
         type:

--- a/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
@@ -136,7 +136,7 @@ class AladinBookSearchApiServiceTest {
 
         // then
         assertAll(
-                () -> assertThat(bookSearchResultResponse.getBookSearchResult().size()).isLessThanOrEqualTo(10),
+                () -> assertThat(bookSearchResultResponse.getBookSearchResult()).hasSizeLessThanOrEqualTo(10),
                 () -> assertThat(bookSearchResultResponse.getNextRequestUrl()).isEqualTo(expectNextRequestUrl),
                 () -> verify(bookSearchRankingService, times(1)).increaseSearchRankingScore(any())
         );

--- a/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiServiceTest.java
@@ -136,7 +136,7 @@ class AladinBookSearchApiServiceTest {
 
         // then
         assertAll(
-                () -> assertThat(bookSearchResultResponse.getBookSearchResult().size()).isLessThan(10),
+                () -> assertThat(bookSearchResultResponse.getBookSearchResult().size()).isLessThanOrEqualTo(10),
                 () -> assertThat(bookSearchResultResponse.getNextRequestUrl()).isEqualTo(expectNextRequestUrl),
                 () -> verify(bookSearchRankingService, times(1)).increaseSearchRankingScore(any())
         );

--- a/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookWriteServiceTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/mybook/domain/MyBookWriteServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -112,6 +113,7 @@ class MyBookWriteServiceTest {
         int holderCount = myBook.getBook().getHolderCount();
 
         given(myBookRepository.findById(any())).willReturn(Optional.of(myBook));
+        doNothing().when(myBookRepository).delete(any());
 
         // when
         myBookWriteService.deleteMyBook(request);
@@ -119,10 +121,8 @@ class MyBookWriteServiceTest {
         // then
         assertAll(
                 () -> verify(myBookRepository).findById(request.getMybookId()),
-                () -> {
-                    assertThat(myBook).isNotNull();
-                    assertThat(myBook.isDeleted()).isTrue();
-                },
+                () -> verify(myBookRepository).delete(myBook),
+                () -> assertThat(myBook).isNotNull(),
                 () -> assertThat(myBook.getBook().getHolderCount()).isEqualTo(holderCount - 1)
         );
     }
@@ -145,7 +145,8 @@ class MyBookWriteServiceTest {
                     assertThat(myBook).isNotNull();
                     assertThat(myBook.isDeleted()).isFalse();
                 },
-                () -> verify(myBookRepository).findById(request.getMybookId())
+                () -> verify(myBookRepository).findById(request.getMybookId()),
+                () -> verify(myBookRepository, never()).delete(any())
         );
     }
 

--- a/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
@@ -562,7 +562,6 @@ class MyBookRepositoryTest {
                 () -> {
                     assertThat(foundMyBook).isPresent();
                     assertThat(foundMyBook.get().getBook()).isNotInstanceOf(HibernateProxy.class);
-                    assertThat(foundMyBook.get().getMyReview()).isNotInstanceOf(HibernateProxy.class);
                     assertThat(foundMyBook.get().getMyReview()).isNull();
                 }
         );

--- a/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/mybook/persistence/MyBookRepositoryTest.java
@@ -535,9 +535,9 @@ class MyBookRepositoryTest {
         // then
         assertAll(
                 () -> {
-                    assertThat(foundMyBook.isPresent()).isTrue();
-                    assertThat(foundMyBook.get().getBook() instanceof HibernateProxy).isFalse();
-                    assertThat(foundMyBook.get().getMyReview() instanceof HibernateProxy).isFalse();
+                    assertThat(foundMyBook).isPresent();
+                    assertThat(foundMyBook.get().getBook()).isNotInstanceOf(HibernateProxy.class);
+                    assertThat(foundMyBook.get().getMyReview()).isNotInstanceOf(HibernateProxy.class);
                 }
         );
     }
@@ -560,9 +560,9 @@ class MyBookRepositoryTest {
         // then
         assertAll(
                 () -> {
-                    assertThat(foundMyBook.isPresent()).isTrue();
-                    assertThat(foundMyBook.get().getBook() instanceof HibernateProxy).isFalse();
-                    assertThat(foundMyBook.get().getMyReview() instanceof HibernateProxy).isFalse();
+                    assertThat(foundMyBook).isPresent();
+                    assertThat(foundMyBook.get().getBook()).isNotInstanceOf(HibernateProxy.class);
+                    assertThat(foundMyBook.get().getMyReview()).isNotInstanceOf(HibernateProxy.class);
                     assertThat(foundMyBook.get().getMyReview()).isNull();
                 }
         );

--- a/book-service/src/test/java/kr/mybrary/bookservice/review/MyReviewFixture.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/review/MyReviewFixture.java
@@ -9,15 +9,14 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum MyReviewFixture {
 
-    COMMON_MY_BOOK_REVIEW(1L, null, null, "마이 리뷰 내용입니다.", 4.5, false),
-    MY_BOOK_REVIEW_WITHOUT_RELATION(null, null, null, "마이 리뷰 내용입니다.", 4.5, false);
+    COMMON_MY_BOOK_REVIEW(1L, null, null, "마이 리뷰 내용입니다.", 4.5),
+    MY_BOOK_REVIEW_WITHOUT_RELATION(null, null, null, "마이 리뷰 내용입니다.", 4.5);
 
     private final Long id;
     private final MyBook myBook;
     private final Book book;
     private final String content;
     private final Double starRating;
-    private final boolean deleted;
 
     public MyReview getMyBookReview() {
         return MyReview.builder()
@@ -26,7 +25,6 @@ public enum MyReviewFixture {
                 .book(book)
                 .content(content)
                 .starRating(starRating)
-                .deleted(deleted)
                 .build();
     }
 
@@ -36,7 +34,6 @@ public enum MyReviewFixture {
                 .myBook(myBook)
                 .book(book)
                 .content(content)
-                .starRating(starRating)
-                .deleted(deleted);
+                .starRating(starRating);
     }
 }

--- a/book-service/src/test/java/kr/mybrary/bookservice/review/domain/MyReviewWriteServiceTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/review/domain/MyReviewWriteServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.times;
 import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.doNothing;
 
 import java.util.Optional;
 import kr.mybrary.bookservice.mybook.MyBookFixture;
@@ -181,16 +182,17 @@ class MyReviewWriteServiceTest {
         Integer originReviewCount = myReview.getBook().getReviewCount();
 
         given(myBookReviewRepository.findByIdWithMyBookUsingFetchJoin(any())).willReturn(Optional.of(myReview));
+        doNothing().when(myBookReviewRepository).delete(myReview);
 
         // when
         myReviewWriteService.delete(request);
 
         // then
         assertAll(
-                () -> assertThat(myReview.isDeleted()).isTrue(),
                 () -> assertThat(myReview.getBook().getStarRating()).isEqualTo(originBookStarRating - originReviewStarRating),
                 () -> assertThat(myReview.getBook().getReviewCount()).isEqualTo(originReviewCount - 1),
-                () -> verify(myBookReviewRepository, times(1)).findByIdWithMyBookUsingFetchJoin(any())
+                () -> verify(myBookReviewRepository, times(1)).findByIdWithMyBookUsingFetchJoin(any()),
+                () -> verify(myBookReviewRepository, times(1)).delete(myReview)
         );
     }
 
@@ -211,7 +213,7 @@ class MyReviewWriteServiceTest {
         assertAll(
                 () -> assertThatThrownBy(() -> myReviewWriteService.delete(request)).isInstanceOf(MyReviewAccessDeniedException.class),
                 () -> verify(myBookReviewRepository, times(1)).findByIdWithMyBookUsingFetchJoin(any()),
-                () -> assertThat(myReview.isDeleted()).isFalse()
+                () -> verify(myBookReviewRepository, never()).delete(myReview)
         );
     }
 }

--- a/book-service/task-definition.json
+++ b/book-service/task-definition.json
@@ -1,0 +1,95 @@
+{
+    "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:133172301128:task-definition/bookServiceFamily:11",
+    "containerDefinitions": [
+        {
+            "name": "bookService",
+            "image": "133172301128.dkr.ecr.ap-northeast-2.amazonaws.com/book-service:image",
+            "cpu": 1024,
+            "portMappings": [
+                {
+                    "name": "bookservice-80-tcp",
+                    "containerPort": 80,
+                    "hostPort": 80,
+                    "protocol": "tcp",
+                    "appProtocol": "http"
+                }
+            ],
+            "essential": true,
+            "environment": [
+                {
+                    "name": "CONFIG_SERVER_URI",
+                    "value": "http://10.0.3.105:8888"
+                }
+            ],
+            "mountPoints": [],
+            "volumesFrom": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-create-group": "true",
+                    "awslogs-group": "/ecs/bookServiceFamily",
+                    "awslogs-region": "ap-northeast-2",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            }
+        }
+    ],
+    "family": "bookServiceFamily",
+    "taskRoleArn": "arn:aws:iam::133172301128:role/ecsTaskExecutionRole",
+    "executionRoleArn": "arn:aws:iam::133172301128:role/ecsTaskExecutionRole",
+    "networkMode": "awsvpc",
+    "revision": 11,
+    "volumes": [],
+    "status": "ACTIVE",
+    "requiresAttributes": [
+        {
+            "name": "com.amazonaws.ecs.capability.logging-driver.awslogs"
+        },
+        {
+            "name": "ecs.capability.execution-role-awslogs"
+        },
+        {
+            "name": "com.amazonaws.ecs.capability.ecr-auth"
+        },
+        {
+            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.19"
+        },
+        {
+            "name": "com.amazonaws.ecs.capability.task-iam-role"
+        },
+        {
+            "name": "ecs.capability.execution-role-ecr-pull"
+        },
+        {
+            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+        },
+        {
+            "name": "ecs.capability.task-eni"
+        },
+        {
+            "name": "com.amazonaws.ecs.capability.docker-remote-api.1.29"
+        }
+    ],
+    "placementConstraints": [],
+    "compatibilities": [
+        "EC2",
+        "FARGATE"
+    ],
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "cpu": "1024",
+    "memory": "2048",
+    "runtimePlatform": {
+        "cpuArchitecture": "X86_64",
+        "operatingSystemFamily": "LINUX"
+    },
+    "registeredAt": "2023-09-14T06:34:42.490Z",
+    "registeredBy": "arn:aws:iam::133172301128:user/soma1415",
+    "tags": [
+        {
+            "key": "Name",
+            "value": "bookService"
+        }
+    ]
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 버그 해결
- 마이북으로 설정한 도서를 마이북 설정 취소시, 도서의 완독 여부, 리뷰 갯수, 별점 등이 줄어들지 않는 문제가 있다.
    - 마이북 삭제 트랜잭션 내에서 해당 속성들도 처리하는 로직 추가 
- 리뷰가 있는 마이북 삭제시, 해당 리뷰의 deleted 가 true로 변경되지 않는다.
    - cascade를 통해 연관 관계도 함께 삭제하도록 수정
- 리뷰를 삭제하고 다시 리뷰 작성시, 작성되지 않는다.
    - 리뷰를 soft delete 하였지만, 마이북과 일대일 관계였기 때문에 다시 리뷰를 작성하지 못하는 문제
    - 리뷰를 hard delete로 수정
- feignClient 문제 해결
    - 블루/그린 배포로 인해 eureka 서버 사용 중단
    - feignClient 사용시, 설정파일에서 user-service의 alb 주소를 읽어와 요청을 보낼 수 있도록 설정. 

### 블루/그린 배포 설정

- Blue와 Green의 서버를 동시에 나란히 구성해둔 상태로 배포 시점에 로드 밸런서가 트래픽을 Blue에서 Green으로 일제히 전환시킨다. 
Green 버전 배포가 성공적으로 완료 되었고, 문제가 없다고 판단했을 때에는 Blue 서버를 제거할 수 있다. 혹은 다음 배포를 위해 유지해둘수 있다.
- 최초 10% 트래픽을 Green으로, 5분 뒤에 Blue에서 Green으로 완전히 전환, 1시간 뒤에 Blue 서버 제거 
- task-definition.json, appspec.yaml 추가
- book-service-ecr-ecs.yml workflow 수정



## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

<!-- 🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다. -->
<!-- 🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
