### PR TITLE
[IDLE-271] 베스트셀러 조회 응답값 추가, CircuitBreaker fallback 설정 변경

### DIFF
--- a/book-service/build.gradle
+++ b/book-service/build.gradle
@@ -46,7 +46,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiService.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiService.java
@@ -14,6 +14,7 @@ import kr.mybrary.bookservice.booksearch.domain.exception.AladinApiUnavailableEx
 import kr.mybrary.bookservice.booksearch.domain.exception.BookSearchResultNotFoundException;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategoryResponseElement;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultWithBookInfoResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
@@ -159,6 +160,42 @@ public class AladinBookSearchApiService implements PlatformBookSearchApiService 
                 .toList();
 
         return BookListByCategorySearchResultResponse.of(bookSearchResultServiceResponses);
+    }
+
+    @Override
+    @Cacheable(cacheNames = "bookListByCategoryWithBookInfo", key = "#request.type + '_' + #request.categoryId + '_' + #request.page", cacheManager = "cacheManager")
+    @Retry(name = RETRY_CONFIG, fallbackMethod = "searchBookListByCategoryFallback")
+    @CircuitBreaker(name = CIRCUIT_BREAKER_CONFIG, fallbackMethod = "searchBookListByCategoryFallback")
+    public BookListByCategorySearchResultWithBookInfoResponse searchBookListByCategoryWithBookInfo(
+            BookListByCategorySearchServiceRequest request) {
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(BOOK_LIST_BY_CATEGORY_SEARCH_URL)
+                .queryParam("TTBKey", API_KEY)
+                .queryParam("QueryType", request.getType())
+                .queryParam("MaxResults", REQUEST_MAX_RESULTS_10)
+                .queryParam("Start", String.valueOf(request.getPage()))
+                .queryParam("Output", REQUEST_OUTPUT)
+                .queryParam("Version", REQUEST_VERSION)
+                .queryParam("CategoryId", String.valueOf(request.getCategoryId()))
+                .queryParam("SearchTarget", "BOOK")
+                .queryParam("Cover", REQUEST_COVER_SIZE);
+
+        ResponseEntity<AladinBookListByCategorySearchResponse> searchResponse = restTemplate.exchange(
+                uriBuilder.build(false).toUriString(),
+                HttpMethod.GET,
+                null,
+                AladinBookListByCategorySearchResponse.class);
+
+        AladinBookListByCategorySearchResponse response = Objects.requireNonNull(searchResponse.getBody());
+
+        checkIfSearchResultExists(response.getTotalResults());
+
+        List<BookListByCategorySearchResultWithBookInfoResponse.Element> elements = response.getItem().stream()
+                .filter(book -> hasISBN13(book.getIsbn13()))
+                .map(BookSearchDtoMapper.INSTANCE::aladinBookListByCategorySearchResponseToResponseWithBookInfo)
+                .toList();
+
+        return BookListByCategorySearchResultWithBookInfoResponse.of(elements);
     }
 
     private BookSearchResultResponse searchWithKeywordFallback(BookSearchServiceRequest request, Exception ex) {

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiService.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/AladinBookSearchApiService.java
@@ -40,11 +40,11 @@ public class AladinBookSearchApiService implements PlatformBookSearchApiService 
     @Value("${aladin.api.key}")
     private String API_KEY;
 
-    private static final String REQUEST_OUTPUT = "js";
-    private static final String REQUEST_VERSION = "20131101";
+    private static final String REQUEST_OUTPUT_JS = "js";
+    private static final String REQUEST_VERSION_20131101 = "20131101";
     private static final String REQUEST_MAX_RESULTS_10 = "10";
     private static final String REQUEST_MAX_RESULTS_20 = "20";
-    private static final String REQUEST_COVER_SIZE = "Big";
+    private static final String REQUEST_COVER_BIG_SIZE = "Big";
     private static final String REQUEST_COVER_MID_BIG_SIZE = "MidBig";
     private static final String CIRCUIT_BREAKER_CONFIG = "aladinAPICircuitBreakerConfig";
     private static final String RETRY_CONFIG = "aladinAPIRetryConfig";
@@ -65,8 +65,8 @@ public class AladinBookSearchApiService implements PlatformBookSearchApiService 
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(BOOK_SEARCH_URL)
                 .queryParam("TTBKey", API_KEY)
-                .queryParam("Output", REQUEST_OUTPUT)
-                .queryParam("Version", REQUEST_VERSION)
+                .queryParam("Output", REQUEST_OUTPUT_JS)
+                .queryParam("Version", REQUEST_VERSION_20131101)
                 .queryParam("Query", request.getKeyword())
                 .queryParam("Start", String.valueOf(request.getPage()))
                 .queryParam("MaxResults", REQUEST_MAX_RESULTS_20)
@@ -106,10 +106,10 @@ public class AladinBookSearchApiService implements PlatformBookSearchApiService 
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(BOOK_DETAIL_SEARCH_URL)
                 .queryParam("TTBKey", API_KEY)
-                .queryParam("Output", REQUEST_OUTPUT)
-                .queryParam("Version", REQUEST_VERSION)
+                .queryParam("Output", REQUEST_OUTPUT_JS)
+                .queryParam("Version", REQUEST_VERSION_20131101)
                 .queryParam("ItemId", request.getKeyword())
-                .queryParam("Cover", REQUEST_COVER_SIZE)
+                .queryParam("Cover", REQUEST_COVER_BIG_SIZE)
                 .queryParam("ItemIdType", "ISBN13")
                 .queryParam("OptResult", "packing,ratingInfo,authors,fulldescription,Toc");
 
@@ -137,11 +137,11 @@ public class AladinBookSearchApiService implements PlatformBookSearchApiService 
                 .queryParam("QueryType", request.getType())
                 .queryParam("MaxResults", REQUEST_MAX_RESULTS_10)
                 .queryParam("Start", String.valueOf(request.getPage()))
-                .queryParam("Output", REQUEST_OUTPUT)
-                .queryParam("Version", REQUEST_VERSION)
+                .queryParam("Output", REQUEST_OUTPUT_JS)
+                .queryParam("Version", REQUEST_VERSION_20131101)
                 .queryParam("CategoryId", String.valueOf(request.getCategoryId()))
                 .queryParam("SearchTarget", "BOOK")
-                .queryParam("Cover", REQUEST_COVER_SIZE);
+                .queryParam("Cover", REQUEST_COVER_BIG_SIZE);
 
         ResponseEntity<AladinBookListByCategorySearchResponse> searchResponse = restTemplate.exchange(
                 uriBuilder.build(false).toUriString(),
@@ -174,11 +174,11 @@ public class AladinBookSearchApiService implements PlatformBookSearchApiService 
                 .queryParam("QueryType", request.getType())
                 .queryParam("MaxResults", REQUEST_MAX_RESULTS_10)
                 .queryParam("Start", String.valueOf(request.getPage()))
-                .queryParam("Output", REQUEST_OUTPUT)
-                .queryParam("Version", REQUEST_VERSION)
+                .queryParam("Output", REQUEST_OUTPUT_JS)
+                .queryParam("Version", REQUEST_VERSION_20131101)
                 .queryParam("CategoryId", String.valueOf(request.getCategoryId()))
                 .queryParam("SearchTarget", "BOOK")
-                .queryParam("Cover", REQUEST_COVER_SIZE);
+                .queryParam("Cover", REQUEST_COVER_BIG_SIZE);
 
         ResponseEntity<AladinBookListByCategorySearchResponse> searchResponse = restTemplate.exchange(
                 uriBuilder.build(false).toUriString(),

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/KakaoBookSearchApiService.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/KakaoBookSearchApiService.java
@@ -10,6 +10,7 @@ import kr.mybrary.bookservice.booksearch.domain.dto.response.kakaoapi.KakaoBookS
 import kr.mybrary.bookservice.booksearch.domain.exception.BookSearchResultNotFoundException;
 import kr.mybrary.bookservice.booksearch.domain.exception.UnsupportedSearchAPIException;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultWithBookInfoResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
@@ -80,6 +81,12 @@ public class KakaoBookSearchApiService implements PlatformBookSearchApiService {
 
     @Override
     public BookListByCategorySearchResultResponse searchBookListByCategory(BookListByCategorySearchServiceRequest request) {
+        throw new UnsupportedSearchAPIException();
+    }
+
+    @Override
+    public BookListByCategorySearchResultWithBookInfoResponse searchBookListByCategoryWithBookInfo(
+            BookListByCategorySearchServiceRequest request) {
         throw new UnsupportedSearchAPIException();
     }
 

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/PlatformBookSearchApiService.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/PlatformBookSearchApiService.java
@@ -3,6 +3,7 @@ package kr.mybrary.bookservice.booksearch.domain;
 import kr.mybrary.bookservice.booksearch.domain.dto.request.BookListByCategorySearchServiceRequest;
 import kr.mybrary.bookservice.booksearch.domain.dto.request.BookSearchServiceRequest;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultWithBookInfoResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponse;
 
@@ -13,4 +14,6 @@ public interface PlatformBookSearchApiService {
     BookSearchDetailResponse searchBookDetailWithISBN(BookSearchServiceRequest request);
 
     BookListByCategorySearchResultResponse searchBookListByCategory(BookListByCategorySearchServiceRequest request);
+
+    BookListByCategorySearchResultWithBookInfoResponse searchBookListByCategoryWithBookInfo(BookListByCategorySearchServiceRequest request);
 }

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/dto/BookSearchDtoMapper.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/domain/dto/BookSearchDtoMapper.java
@@ -1,15 +1,16 @@
 package kr.mybrary.bookservice.booksearch.domain.dto;
 
 import java.util.List;
-import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategoryResponseElement;
-import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookListByCategorySearchResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookSearchResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.kakaoapi.KakaoBookSearchResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategoryResponseElement;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultWithBookInfoResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse.Author;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse.Translator;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -87,11 +88,16 @@ public interface BookSearchDtoMapper {
     @Mapping(target = "interestCount", constant = "0")
     BookSearchDetailResponse aladinSearchResponseToDetailResponse(AladinBookSearchDetailResponse.Item aladinBookSearchResponse);
 
-
     @Mapping(target = "thumbnailUrl", source = "cover")
     BookListByCategoryResponseElement aladinBookListByCategorySearchResponseToServiceResponse(
             AladinBookListByCategorySearchResponse.Item aladinBookListByCategorySearchResponse);
 
+    @Mapping(target = "thumbnailUrl", source = "cover")
+    @Mapping(target = "title", source = "title")
+    @Mapping(target = "authors", source = "author", qualifiedByName = "getAuthorNames")
+    @Mapping(target = "aladinStarRating", expression = "java(aladinBookListByCategorySearchResponse.getCustomerReviewRank() / 2.0)")
+    BookListByCategorySearchResultWithBookInfoResponse.Element aladinBookListByCategorySearchResponseToResponseWithBookInfo(
+            AladinBookListByCategorySearchResponse.Item aladinBookListByCategorySearchResponse);
 
     @Named("getISBN10")
     static String getISBN10(String isbn) {
@@ -119,6 +125,11 @@ public interface BookSearchDtoMapper {
                         .authorId(0)
                         .build())
                 .toList();
+    }
+
+    @Named("getAuthorNames")
+    static String getAuthorNames(String author) {
+        return author.replaceAll(" \\(지은이\\).*", "");
     }
 
     @Named("mappingTranslatorNames")

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/BookSearchController.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/BookSearchController.java
@@ -54,7 +54,7 @@ public class BookSearchController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.of(HttpStatus.OK.toString(), "카테고리별 도서 리스트 조회에 성공했습니다.",
-                        bookService.searchBookListByCategory(request)));
+                        bookService.searchBookListByCategoryWithBookInfo(request)));
     }
 
     @GetMapping("/recommendations/{type}/categories/{categoryId}")

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/BookSearchController.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/BookSearchController.java
@@ -4,6 +4,11 @@ import kr.mybrary.bookservice.booksearch.domain.BookSearchRankingService;
 import kr.mybrary.bookservice.booksearch.domain.PlatformBookSearchApiService;
 import kr.mybrary.bookservice.booksearch.domain.dto.request.BookListByCategorySearchServiceRequest;
 import kr.mybrary.bookservice.booksearch.domain.dto.request.BookSearchServiceRequest;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultWithBookInfoResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchRankingResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponse;
 import kr.mybrary.bookservice.global.dto.response.FeignClientResponse;
 import kr.mybrary.bookservice.global.dto.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +29,7 @@ public class BookSearchController {
     private final BookSearchRankingService bookSearchRankingService;
 
     @GetMapping("/search")
-    public ResponseEntity searchWithKeyword(
+    public ResponseEntity<SuccessResponse<BookSearchResultResponse>> searchWithKeyword(
             @RequestParam(value = "keyword") String keyword,
             @RequestParam(value = "sort", required = false, defaultValue = "accuracy") String sort,
             @RequestParam(value = "page", required = false, defaultValue = "1") int page) {
@@ -36,7 +41,7 @@ public class BookSearchController {
     }
 
     @GetMapping("/search/detail")
-    public ResponseEntity searchBookDetailWithISBN(@RequestParam("isbn") String isbn) {
+    public ResponseEntity<SuccessResponse<BookSearchDetailResponse>> searchBookDetailWithISBN(@RequestParam("isbn") String isbn) {
 
         BookSearchServiceRequest request = BookSearchServiceRequest.of(isbn);
 
@@ -45,7 +50,7 @@ public class BookSearchController {
     }
 
     @GetMapping("/recommendations")
-    public ResponseEntity getBookRecommendations(
+    public ResponseEntity<SuccessResponse<BookListByCategorySearchResultWithBookInfoResponse>> getBookRecommendations(
             @RequestParam(value = "type") String type,
             @RequestParam(value = "categoryId", required = false, defaultValue = "0") int categoryId,
             @RequestParam(value = "page", required = false, defaultValue = "1") int page) {
@@ -58,7 +63,7 @@ public class BookSearchController {
     }
 
     @GetMapping("/recommendations/{type}/categories/{categoryId}")
-    public ResponseEntity getBookRecommendationsCalledByFeignClient(
+    public ResponseEntity<FeignClientResponse<BookListByCategorySearchResultResponse>> getBookRecommendationsCalledByFeignClient(
             @PathVariable String type,
             @PathVariable int categoryId,
             @RequestParam(value = "page", required = false, defaultValue = "1") int page) {
@@ -70,7 +75,7 @@ public class BookSearchController {
     }
 
     @GetMapping("/search/ranking")
-    public ResponseEntity searchRanking() {
+    public ResponseEntity<SuccessResponse<BookSearchRankingResponse>> searchRanking() {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.of(HttpStatus.OK.toString(), "도서 검색 랭킹 조회에 성공했습니다.",

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/dto/response/BookListByCategorySearchResultWithBookInfoResponse.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/dto/response/BookListByCategorySearchResultWithBookInfoResponse.java
@@ -1,0 +1,28 @@
+package kr.mybrary.bookservice.booksearch.presentation.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookListByCategorySearchResultWithBookInfoResponse {
+
+    private List<Element> books;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Element {
+        private String thumbnailUrl;
+        private String isbn13;
+        private String title;
+        private String authors;
+        private Double aladinStarRating;
+    }
+}

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/dto/response/BookListByCategorySearchResultWithBookInfoResponse.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/dto/response/BookListByCategorySearchResultWithBookInfoResponse.java
@@ -25,4 +25,10 @@ public class BookListByCategorySearchResultWithBookInfoResponse {
         private String authors;
         private Double aladinStarRating;
     }
+
+    public static BookListByCategorySearchResultWithBookInfoResponse of(List<Element> bookListByCategorySearchResultElement) {
+        return BookListByCategorySearchResultWithBookInfoResponse.builder()
+                .books(bookListByCategorySearchResultElement)
+                .build();
+    }
 }

--- a/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/dto/response/BookListByCategorySearchResultWithBookInfoResponse.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/booksearch/presentation/dto/response/BookListByCategorySearchResultWithBookInfoResponse.java
@@ -4,11 +4,9 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class BookListByCategorySearchResultWithBookInfoResponse {
 
@@ -16,7 +14,6 @@ public class BookListByCategorySearchResultWithBookInfoResponse {
 
     @Getter
     @Builder
-    @NoArgsConstructor
     @AllArgsConstructor
     public static class Element {
         private String thumbnailUrl;

--- a/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/client/user/api/UserServiceClient.java
@@ -22,7 +22,7 @@ public interface UserServiceClient {
     @CircuitBreaker(name = "userServiceCircuitBreakerConfig", fallbackMethod = "getUsersInfoFallback")
     UserInfoServiceResponse getUsersInfo(@RequestParam("userId") List<String> userIds);
 
-    default UserInfoServiceResponse getUsersInfoFallback(List<String> userIds) {
+    default UserInfoServiceResponse getUsersInfoFallback(List<String> userIds, Exception ex) {
         return UserInfoServiceResponse.builder()
                 .data(makeTemporaryResponse(userIds))
                 .build();
@@ -42,6 +42,10 @@ public interface UserServiceClient {
 
     @NotNull
     private String makeTemporaryNickname(String userId) {
+        if (userId.length() < 5) {
+            return "user_" + userId.toLowerCase();
+        }
+
         return "user_" + userId.substring(0, 5).toLowerCase();
     }
 }

--- a/book-service/src/main/java/kr/mybrary/bookservice/global/redis/CacheKey.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/global/redis/CacheKey.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum CacheKey {
 
     BOOK_LIST_BY_CATEGORY("bookSearch", "bookListByCategory", CacheTTL.ONE_WEEK.getExpireTimeSeconds()),
+    BOOK_LIST_BY_CATEGORY_WITH_BOOK_INFO("bookSearch", "bookListByCategoryWithBookInfo", CacheTTL.ONE_WEEK.getExpireTimeSeconds()),
     BOOK_LIST_BY_SEARCH_KEYWORD("bookSearch", "bookListBySearchKeyword", CacheTTL.ONE_WEEK.getExpireTimeSeconds());
 
     private final String prefix;

--- a/book-service/src/main/resources/application-local.yml
+++ b/book-service/src/main/resources/application-local.yml
@@ -45,7 +45,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: refresh,health,beans
+        include: refresh,health,beans,metrics,prometheus
 
 logging:
   level:
@@ -55,3 +55,8 @@ retry:
   bookSave:
     maxAttempts: 5
     maxDelay : 1000
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true

--- a/book-service/src/test/java/kr/mybrary/bookservice/booksearch/BookSearchDtoTestData.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/booksearch/BookSearchDtoTestData.java
@@ -4,14 +4,15 @@ import java.util.List;
 import kr.mybrary.bookservice.booksearch.domain.dto.request.BookListByCategorySearchServiceRequest;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookListByCategorySearchResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookListByCategorySearchResponse.Item;
-import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategoryResponseElement;
-import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchRankingResponse;
-import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookSearchResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.kakaoapi.KakaoBookSearchResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategoryResponseElement;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultWithBookInfoResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchRankingResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
 
 public class BookSearchDtoTestData {
 
@@ -263,5 +264,25 @@ public class BookSearchDtoTestData {
                 .cover("https://sample-cover.com")
                 .customerReviewRank(8)
                 .build();
+    }
+
+    public static BookListByCategorySearchResultWithBookInfoResponse createBookListByCategorySearchResultWithBookInfoResponse() {
+        return BookListByCategorySearchResultWithBookInfoResponse.builder()
+                .books(List.of(
+                        BookListByCategorySearchResultWithBookInfoResponse.Element.builder()
+                            .title("title_1")
+                            .isbn13("isbn13_1")
+                            .authors("authors_1")
+                            .thumbnailUrl("thumbnail_url_1")
+                            .aladinStarRating(4.0)
+                            .build(),
+                        BookListByCategorySearchResultWithBookInfoResponse.Element.builder()
+                            .title("title_2")
+                            .isbn13("isbn13_2")
+                            .authors("authors_2, authors_3")
+                            .thumbnailUrl("thumbnail_url_2")
+                            .aladinStarRating(3.5)
+                            .build())
+                ).build();
     }
 }

--- a/book-service/src/test/java/kr/mybrary/bookservice/booksearch/BookSearchDtoTestData.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/booksearch/BookSearchDtoTestData.java
@@ -2,6 +2,8 @@ package kr.mybrary.bookservice.booksearch;
 
 import java.util.List;
 import kr.mybrary.bookservice.booksearch.domain.dto.request.BookListByCategorySearchServiceRequest;
+import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookListByCategorySearchResponse;
+import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookListByCategorySearchResponse.Item;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategoryResponseElement;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchRankingResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
@@ -249,6 +251,17 @@ public class BookSearchDtoTestData {
                                 .keyword("감동")
                                 .score(3.0)
                                 .build()))
+                .build();
+    }
+
+    public static AladinBookListByCategorySearchResponse.Item createAladinBookListByCategorySearchResponseItem() {
+        return Item.builder()
+                .title("Sample Book Title - Sub Title")
+                .link("https://sample-link.com")
+                .author("John Doe 1, John Doe 2 (지은이)")
+                .isbn13("9781234567890")
+                .cover("https://sample-cover.com")
+                .customerReviewRank(8)
                 .build();
     }
 }

--- a/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/BookSearchDtoMapperTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/BookSearchDtoMapperTest.java
@@ -1,20 +1,24 @@
 package kr.mybrary.bookservice.booksearch.domain;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import kr.mybrary.bookservice.booksearch.BookSearchDtoTestData;
-import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
 import kr.mybrary.bookservice.booksearch.domain.dto.BookSearchDtoMapper;
+import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookListByCategorySearchResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookSearchResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.aladinapi.AladinBookSearchResponse.Item;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.kakaoapi.KakaoBookSearchResponse;
 import kr.mybrary.bookservice.booksearch.domain.dto.response.kakaoapi.KakaoBookSearchResponse.Document;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultWithBookInfoResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse.Author;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse.Translator;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponseElement;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -289,4 +293,48 @@ class BookSearchDtoMapperTest {
                 () -> assertThat(dto.getInterestCount()).isEqualTo(0)
         );
     }
+
+    @DisplayName("알라딘의 author 응답값에서 지은이 이름만 가져온다.")
+    @Test
+    void getAuthorNames() {
+
+        // given
+        String givenAuthor_1 = "지 은 이 1 (지은이), 옮긴이1 (옮긴이)";
+        String givenAuthor_2 = "지은이1, 지은이2 (지은이)";
+        String givenAuthor_3 = "지은이1";
+
+        // when
+        String authorNames_1 = BookSearchDtoMapper.getAuthorNames(givenAuthor_1);
+        String authorNames_2 = BookSearchDtoMapper.getAuthorNames(givenAuthor_2);
+        String authorNames_3 = BookSearchDtoMapper.getAuthorNames(givenAuthor_3);
+
+        // then
+        assertAll(
+                () -> assertThat(authorNames_1).isEqualTo("지 은 이 1"),
+                () -> assertThat(authorNames_2).isEqualTo("지은이1, 지은이2"),
+                () -> assertThat(authorNames_3).isEqualTo("지은이1")
+        );
+    }
+
+    @DisplayName("알라딘 카테고리 조회 결과를 BookListByCategorySearchResultWithBookInfoResponse.Element 로 매핑한다.")
+    @Test
+    void aladinBookListByCategorySearchResponseToResponseWithBookInfo() {
+
+        // given
+        AladinBookListByCategorySearchResponse.Item response = BookSearchDtoTestData.createAladinBookListByCategorySearchResponseItem();
+
+        // when
+        BookListByCategorySearchResultWithBookInfoResponse.Element dto =
+                BookSearchDtoMapper.INSTANCE.aladinBookListByCategorySearchResponseToResponseWithBookInfo(response);
+
+        // then
+        assertAll(
+                () -> assertThat(dto.getThumbnailUrl()).isEqualTo(response.getCover()),
+                () -> assertThat(dto.getIsbn13()).isEqualTo(response.getIsbn13()),
+                () -> assertThat(dto.getTitle()).isEqualTo(response.getTitle()),
+                () -> assertThat(dto.getAuthors()).isEqualTo(BookSearchDtoMapper.getAuthorNames(response.getAuthor())),
+                () -> assertThat(dto.getAladinStarRating()).isEqualTo(response.getCustomerReviewRank() / 2.0)
+        );
+    }
+
 }

--- a/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/KakaoBookSearchApiServiceTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/booksearch/domain/KakaoBookSearchApiServiceTest.java
@@ -193,6 +193,18 @@ class KakaoBookSearchApiServiceTest {
                 UnsupportedSearchAPIException.class);
         mockServer.verify();
     }
+    @DisplayName("지원되지 않는 플랫폼에서 도서 분야별 리스트 조회시 예외가 발생한다. 2")
+    @Test
+    void occurExceptionWhenSearchBookListWithBookInfoByField() {
+
+        // given
+        BookListByCategorySearchServiceRequest request = BookSearchDtoTestData.createBookListSearchServiceRequest();
+
+        // given, when
+        assertThatThrownBy(() -> kakaoBookSearchApiService.searchBookListByCategoryWithBookInfo(request)).isInstanceOf(
+                UnsupportedSearchAPIException.class);
+        mockServer.verify();
+    }
 
     private String readJsonFile(String fileName) throws IOException {
         return new String(Files.readAllBytes(Paths.get(JSON_FILE_PATH + fileName)));

--- a/book-service/src/test/java/kr/mybrary/bookservice/booksearch/presentation/BookSearchControllerTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/booksearch/presentation/BookSearchControllerTest.java
@@ -25,6 +25,7 @@ import kr.mybrary.bookservice.booksearch.domain.AladinBookSearchApiService;
 import kr.mybrary.bookservice.booksearch.domain.BookSearchRankingService;
 import kr.mybrary.bookservice.booksearch.domain.dto.request.BookListByCategorySearchServiceRequest;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultResponse;
+import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookListByCategorySearchResultWithBookInfoResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchDetailResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchRankingResponse;
 import kr.mybrary.bookservice.booksearch.presentation.dto.response.BookSearchResultResponse;
@@ -223,9 +224,9 @@ class BookSearchControllerTest {
     void getBookRecommendations() throws Exception {
 
         // given
-        BookListByCategorySearchResultResponse response = BookSearchDtoTestData.createBookListSearchResultResponse();
+        BookListByCategorySearchResultWithBookInfoResponse response = BookSearchDtoTestData.createBookListByCategorySearchResultWithBookInfoResponse();
         BookListByCategorySearchServiceRequest request = BookSearchDtoTestData.createBookListSearchServiceRequest();
-        given(aladinBookSearchApiService.searchBookListByCategory(any())).willReturn(response);
+        given(aladinBookSearchApiService.searchBookListByCategoryWithBookInfo(any())).willReturn(response);
 
         // when
         ResultActions actions = mockMvc.perform(get("/api/v1/books/recommendations")
@@ -259,7 +260,10 @@ class BookSearchControllerTest {
                                                 fieldWithPath("status").type(STRING).description("응답 상태"),
                                                 fieldWithPath("message").type(STRING).description("응답 메시지"),
                                                 fieldWithPath("data.books[].isbn13").type(STRING).description("도서 ISBN13"),
-                                                fieldWithPath("data.books[].thumbnailUrl").type(STRING).description("도서 썸네일 URL")
+                                                fieldWithPath("data.books[].thumbnailUrl").type(STRING).description("도서 썸네일 URL"),
+                                                fieldWithPath("data.books[].title").type(STRING).description("도서 제목"),
+                                                fieldWithPath("data.books[].authors").type(STRING).description("도서 저자"),
+                                                fieldWithPath("data.books[].aladinStarRating").type(NUMBER).description("도서 별점")
                                         ).build())));
     }
 

--- a/book-service/src/test/java/kr/mybrary/bookservice/client/user/api/UserServiceClientTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/client/user/api/UserServiceClientTest.java
@@ -1,0 +1,34 @@
+package kr.mybrary.bookservice.client.user.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import kr.mybrary.bookservice.client.user.dto.response.UserInfoServiceResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserServiceClientTest {
+
+    private final String DEFAULT_PROFILE_IMAGE_URL = "https://mybrary-user-service-resized.s3.ap-northeast-2.amazonaws.com/tiny-profile/profileImage/default.jpg";
+
+    @DisplayName("feignClient로 유저 정보 조회가 실패하면, 임시 유저 정보를 반환한다. (fallback)")
+    @Test
+    void getUsersInfoFallback() {
+
+        // given
+        List<String> userIds = List.of("USER_ID_1", "USER_ID_2", "US_3");
+        UserServiceClient userServiceClient = userIds1 -> null;
+
+        // when
+        UserInfoServiceResponse response = userServiceClient.getUsersInfoFallback(userIds, new Exception());
+
+        // then
+        assertAll(
+                () -> assertThat(response.getData().getUserInfoElements()).hasSize(3),
+                () -> assertThat(response.getData().getUserInfoElements()).extracting("userId").containsExactly("USER_ID_1", "USER_ID_2", "US_3"),
+                () -> assertThat(response.getData().getUserInfoElements()).extracting("nickname").containsExactly("user_user_", "user_user_", "user_us_3"),
+                () -> assertThat(response.getData().getUserInfoElements()).extracting("profileImageUrl").containsExactly(DEFAULT_PROFILE_IMAGE_URL, DEFAULT_PROFILE_IMAGE_URL, DEFAULT_PROFILE_IMAGE_URL)
+        );
+    }
+}


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 베스트셀러 조회 응답값 추가
- `베스트 셀러 조회 API`와 `관심사 기반 베스트 셀러 조회 API`가 기존에 같은 서비스 계층의 코드를 호출
    - 요구 사항 변경으로 `베스트 셀러 조회 API`의 응답값이 변경되었기 때문에, 기존의 서비스 계층의 코드를 변경하면 `관심사 기반 베스트 셀러 조회 API`의 응답값도 변경되는 문제가 생긴다.
- `베스트 셀러 조회 API`와 `관심사 기반 베스트 셀러 조회 API`가 호출하는 서비스 계층 코드 분리
- `베스트 셀러 조회 API`의 응답
``` java 
private String thumbnailUrl;
private String isbn13;
private String title;
private String authors;
private Double aladinStarRating;
```
- `관심사 기반 베스트 셀러 조회 API`의 응답
``` java
private String thumbnailUrl;
private String isbn13;
```

- 베스트 셀러 조회 API
- GET "/api/v1/books/recommendations"
- 응답
``` json
{
  "status": "200 OK",
  "message": "카테고리별 도서 리스트 조회에 성공했습니다.",
  "data": {
    "books": [
      {
        "thumbnailUrl": "thumbnail_url_1",
        "isbn13": "isbn13_1",
        "title": "title_1",
        "authors": "authors_1",
        "aladinStarRating": 4
      },
      {
        "thumbnailUrl": "thumbnail_url_2",
        "isbn13": "isbn13_2",
        "title": "title_2",
        "authors": "authors_2, authors_3",
        "aladinStarRating": 3.5
      }
    ]
  }
}
```

<br/>
<br/>

### CircuitBreaker fallback 설정 변경
<img width="1389" alt="image" src="https://github.com/SWM-IDLE/mybrary-book-service/assets/71378475/d8fb59ea-ba0e-4d5d-9ecc-5a7e9c2b2d1a">

- 한 도서에 대해서 리뷰 조회시, 위와 같은 경고 발생
    - feginClient를 사용하는 부분이기 때문에 CircuitBreaker를 설정했고, fallback 함수를 설정했으나 fallback 함수를 찾지 못한다는 경고
    - fallback 함수의 경우, 대상의 되는 함수의 반환값과 매개변수가 같아야 하며, 실제 매개변수로 Exception 을 함께 받아야 한다.
- 기존 코드에는 Exception을 매개변수로 받지 않아 발생하는 오류, Exception을 추가 하여 문제 해결

``` java
  @GetMapping("/api/v1/users/info")
  @Headers("Content-Type: application/json")
  @Retry(name = "userServiceRetryConfig", fallbackMethod = "getUsersInfoFallback")
  @CircuitBreaker(name = "userServiceCircuitBreakerConfig", fallbackMethod = "getUsersInfoFallback")
  UserInfoServiceResponse getUsersInfo(@RequestParam("userId") List<String> userIds);

  default UserInfoServiceResponse getUsersInfoFallback(List<String> userIds, Exception ex) {
      return UserInfoServiceResponse.builder()
              .data(makeTemporaryResponse(userIds))
              .build();
  }
```

<br/>
<br/>

### 모니터링을 위해 Prometheus 의존성 추가
- Prometheus 의존성 추가
```
implementation 'io.micrometer:micrometer-registry-prometheus'
```

- actuator 엔드포인트 추가
```
management:
  endpoints:
    web:
      exposure:
        include: refresh,health,beans,metrics,prometheus
```

- 톰캣 메트릭 설정
    - 아래 설정이 없으면, tomcat.session에 대한 정보만 확인가능
    - 아래 설정을 통해 톰캣의 최대 쓰레드, 사용 쓰레드 수를 포함한 다양한 메트릭을 확인 가능
    - config-repository에도 추가할 예정입니다.
``` yaml
server:
    tomcat:
        mbeanregistry:
            enabled: true
```
<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

🐢 천천히 : 급하지 않습니다.

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
