### PR TITLE
[IDLE-204] config: task-definition ecs service discovery 추가

### DIFF
--- a/book-service/task-definition.json
+++ b/book-service/task-definition.json
@@ -84,6 +84,11 @@
         "cpuArchitecture": "X86_64",
         "operatingSystemFamily": "LINUX"
     },
+    "serviceRegistries": [
+        {
+            "registryArn": "arn:aws:servicediscovery:ap-northeast-2:133172301128:namespace/ns-ntxns7edxn5msrkp"
+        }
+    ],
     "registeredAt": "2023-09-14T06:34:42.490Z",
     "registeredBy": "arn:aws:iam::133172301128:user/soma1415",
     "tags": [


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 프로메테우스 데이터 수집
- ecs에서 동작하는 서비스의 IP와 Port 정보를 읽어오기 위해서, task-definition에 설정을 추가했습니다.
<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

<!-- 🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다. -->
<!-- 🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
