### PR TITLE
[IDLE-297] 추천 피드 API 버그 수정

### DIFF
--- a/book-service/src/main/java/kr/mybrary/bookservice/recommend/persistence/RecommendationFeed.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/recommend/persistence/RecommendationFeed.java
@@ -16,16 +16,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Where(clause = "deleted = false")
-@SQLDelete(sql = "UPDATE recommendation_feed SET deleted = true WHERE id = ?")
 public class RecommendationFeed extends BaseEntity {
 
     @Id
@@ -40,7 +36,6 @@ public class RecommendationFeed extends BaseEntity {
 
     private String userId;
     private String content;
-    private boolean deleted;
 
     public static RecommendationFeed of(RecommendationFeedCreateServiceRequest request, MyBook myBook, RecommendationTargets recommendationTargets) {
         return RecommendationFeed.builder()

--- a/book-service/src/main/java/kr/mybrary/bookservice/recommend/persistence/RecommendationTarget.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/recommend/persistence/RecommendationTarget.java
@@ -11,16 +11,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Where(clause = "deleted = false")
-@SQLDelete(sql = "UPDATE recommendation_target SET deleted = true WHERE id = ?")
 public class RecommendationTarget extends BaseEntity {
 
     @Id
@@ -31,8 +27,6 @@ public class RecommendationTarget extends BaseEntity {
     private RecommendationFeed recommendationFeed;
 
     private String targetName;
-
-    private boolean deleted;
 
     public static RecommendationTarget of(String targetName) {
         return RecommendationTarget.builder()

--- a/book-service/src/main/java/kr/mybrary/bookservice/recommend/persistence/model/RecommendationFeedOfUserViewModel.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/recommend/persistence/model/RecommendationFeedOfUserViewModel.java
@@ -16,6 +16,7 @@ public class RecommendationFeedOfUserViewModel {
 
     private String content;
     private List<RecommendationTargetOfUserModel> recommendationTargets;
+    private List<RecommendationFeedOfUserBookAuthorModel> bookAuthors;
 
     private Long recommendationFeedId;
     private Long myBookId;
@@ -29,6 +30,10 @@ public class RecommendationFeedOfUserViewModel {
         this.recommendationTargets = recommendationTargetOfUserModels;
     }
 
+    public void setBookAuthors(List<RecommendationFeedOfUserBookAuthorModel> bookAuthors) {
+        this.bookAuthors = bookAuthors;
+    }
+
     @Getter
     @Builder
     @NoArgsConstructor
@@ -38,5 +43,17 @@ public class RecommendationFeedOfUserViewModel {
 
         private Long targetId;
         private String targetName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    public static class RecommendationFeedOfUserBookAuthorModel {
+
+        private Long authorId;
+        private Integer aid;
+        private String name;
     }
 }

--- a/book-service/src/main/java/kr/mybrary/bookservice/recommend/presentation/dto/response/RecommendationFeedOfUserViewResponse.java
+++ b/book-service/src/main/java/kr/mybrary/bookservice/recommend/presentation/dto/response/RecommendationFeedOfUserViewResponse.java
@@ -3,6 +3,7 @@ package kr.mybrary.bookservice.recommend.presentation.dto.response;
 import java.util.List;
 import kr.mybrary.bookservice.global.util.DateUtils;
 import kr.mybrary.bookservice.recommend.persistence.model.RecommendationFeedOfUserViewModel;
+import kr.mybrary.bookservice.recommend.persistence.model.RecommendationFeedOfUserViewModel.RecommendationFeedOfUserBookAuthorModel;
 import kr.mybrary.bookservice.recommend.persistence.model.RecommendationFeedOfUserViewModel.RecommendationTargetOfUserModel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,6 +28,8 @@ public class RecommendationFeedOfUserViewResponse {
                                 .createdAt(DateUtils.toDotFormatYYYYMMDD(recommendationFeed.getCreatedAt()))
                                 .recommendationTargetNames(recommendationFeed.getRecommendationTargets().stream()
                                         .map(RecommendationTargetOfUserModel::getTargetName).toList())
+                                .authors(recommendationFeed.getBookAuthors().stream().map(
+                                        RecommendationFeedOfUserBookAuthorModel::getName).toList())
                                 .build()).toList()).build();
     }
 
@@ -44,5 +47,6 @@ public class RecommendationFeedOfUserViewResponse {
         private String createdAt;
 
         private List<String> recommendationTargetNames;
+        private List<String> authors;
     }
 }

--- a/book-service/src/test/java/kr/mybrary/bookservice/recommend/RecommendationFeedDtoTestData.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/recommend/RecommendationFeedDtoTestData.java
@@ -178,6 +178,17 @@ public class RecommendationFeedDtoTestData {
                             .thumbnailUrl("THUMBNAIL_URL_" + i)
                             .isbn13("ISBN13_" + i)
                             .createdAt(LocalDateTime.now())
+                            .bookAuthors(List.of(
+                                    RecommendationFeedOfUserViewModel.RecommendationFeedOfUserBookAuthorModel.builder()
+                                            .authorId((long) i)
+                                            .aid(i)
+                                            .name("AUTHOR_NAME_" + i)
+                                            .build(),
+                                    RecommendationFeedOfUserViewModel.RecommendationFeedOfUserBookAuthorModel.builder()
+                                            .authorId((long) i + 1)
+                                            .aid(i + 1)
+                                            .name("AUTHOR_NAME_" + (i + 1))
+                                            .build()))
                             .recommendationTargets(List.of(
                                     RecommendationFeedOfUserViewModel.RecommendationTargetOfUserModel.builder()
                                             .targetId((long) i)
@@ -204,6 +215,7 @@ public class RecommendationFeedDtoTestData {
                             .title("TITLE_" + i)
                             .thumbnailUrl("THUMBNAIL_URL_" + i)
                             .isbn13("ISBN13_" + i)
+                            .authors(List.of("AUTHOR_NAME_" + i, "AUTHOR_NAME_" + (i + 1)))
                             .createdAt(DateUtils.toDotFormatYYYYMMDD(LocalDateTime.now()))
                             .build()));
 

--- a/book-service/src/test/java/kr/mybrary/bookservice/recommend/RecommendationFeedFixture.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/recommend/RecommendationFeedFixture.java
@@ -2,7 +2,6 @@ package kr.mybrary.bookservice.recommend;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import kr.mybrary.bookservice.mybook.MyBookFixture;
 import kr.mybrary.bookservice.mybook.persistence.MyBook;
 import kr.mybrary.bookservice.recommend.persistence.RecommendationFeed;
@@ -13,18 +12,17 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum RecommendationFeedFixture {
 
-    COMMON_LOGIN_USER_RECOMMENDATION_FEED(1L, MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook(), "LOGIN_USER_ID", "CONTENT EXAMPLE", false,
-            new RecommendationTargets(new ArrayList<>(Arrays.asList(RecommendationTarget.builder().targetName("TARGET_NAME_1").deleted(false).build(),
-                    RecommendationTarget.builder().targetName("TARGET_NAME_2").deleted(false).build())))),
-    COMMON_OTHER_USER_RECOMMENDATION_FEED(1L, MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook(), "OTHER_USER_ID", "CONTENT EXAMPLE", false,
-            new RecommendationTargets(new ArrayList<>(Arrays.asList(RecommendationTarget.builder().targetName("TARGET_NAME_1").deleted(false).build(),
-                    RecommendationTarget.builder().targetName("TARGET_NAME_2").deleted(false).build()))));
+    COMMON_LOGIN_USER_RECOMMENDATION_FEED(1L, MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook(), "LOGIN_USER_ID", "CONTENT EXAMPLE",
+            new RecommendationTargets(new ArrayList<>(Arrays.asList(RecommendationTarget.builder().targetName("TARGET_NAME_1").build(),
+                    RecommendationTarget.builder().targetName("TARGET_NAME_2").build())))),
+    COMMON_OTHER_USER_RECOMMENDATION_FEED(1L, MyBookFixture.COMMON_LOGIN_USER_MYBOOK.getMyBook(), "OTHER_USER_ID", "CONTENT EXAMPLE",
+            new RecommendationTargets(new ArrayList<>(Arrays.asList(RecommendationTarget.builder().targetName("TARGET_NAME_1").build(),
+                    RecommendationTarget.builder().targetName("TARGET_NAME_2").build()))));
 
     private final Long id;
     private final MyBook myBook;
     private final String userId;
     private final String content;
-    private final boolean deleted;
     private final RecommendationTargets recommendationTargets;
 
     public RecommendationFeed getRecommendationFeed() {
@@ -33,7 +31,6 @@ public enum RecommendationFeedFixture {
                 .myBook(myBook)
                 .userId(userId)
                 .content(content)
-                .deleted(deleted)
                 .recommendationTargets(recommendationTargets)
                 .build();
     }

--- a/book-service/src/test/java/kr/mybrary/bookservice/recommend/persistence/repository/RecommendationFeedRepositoryTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/recommend/persistence/repository/RecommendationFeedRepositoryTest.java
@@ -488,21 +488,24 @@ class RecommendationFeedRepositoryTest {
         entityManager.clear();
 
         // when
-        List<RecommendationFeedOfUserViewModel> recommendationFeedViewAll =
+        List<RecommendationFeedOfUserViewModel> recommendationFeedOfUserView =
                 recommendationFeedRepository.getRecommendationFeedViewOfUserModel("LOGIN_USER_ID");
 
         // then
         assertAll(
                 () -> {
-                    assertThat(recommendationFeedViewAll).hasSize(4);
-                    assertThat(recommendationFeedViewAll.get(0).getRecommendationTargets()).extracting("targetName")
+                    assertThat(recommendationFeedOfUserView).hasSize(4);
+                    assertThat(recommendationFeedOfUserView.get(0).getRecommendationTargets()).extracting("targetName")
                             .containsExactly("TARGET_NAME_4");
-                    assertThat(recommendationFeedViewAll.get(3).getRecommendationTargets()).extracting("targetName")
+                    assertThat(recommendationFeedOfUserView.get(3).getRecommendationTargets()).extracting("targetName")
                             .containsExactly("TARGET_NAME_1");
+                    assertThat(recommendationFeedOfUserView.get(0).getBookAuthors()).extracting("name")
+                            .containsExactly("테스트 저자 1", "테스트 저자 2", "테스트 저자 3");
+                    assertThat(recommendationFeedOfUserView.get(3).getBookAuthors()).extracting("name")
+                            .containsExactly("테스트 저자 1", "테스트 저자 2", "테스트 저자 3");
                 },
-                () -> assertThat(recommendationFeedViewAll).extracting("content").containsExactlyInAnyOrder(
-                        "NEW_CONTENT_1", "NEW_CONTENT_2", "NEW_CONTENT_3", "NEW_CONTENT_4"
-                )
+                () -> assertThat(recommendationFeedOfUserView).extracting("content").containsExactlyInAnyOrder(
+                        "NEW_CONTENT_1", "NEW_CONTENT_2", "NEW_CONTENT_3", "NEW_CONTENT_4")
         );
     }
 

--- a/book-service/src/test/java/kr/mybrary/bookservice/recommend/presentation/RecommendationFeedControllerTest.java
+++ b/book-service/src/test/java/kr/mybrary/bookservice/recommend/presentation/RecommendationFeedControllerTest.java
@@ -368,6 +368,9 @@ class RecommendationFeedControllerTest {
                                                 fieldWithPath(
                                                         "data.recommendationFeeds[].recommendationTargetNames").type(ARRAY)
                                                         .description("추천 피드 대상자 목록"),
+                                                fieldWithPath(
+                                                        "data.recommendationFeeds[].authors").type(ARRAY)
+                                                        .description("추천 피드 도서 저자들의 이름"),
                                                 fieldWithPath("data.recommendationFeeds[].myBookId").type(NUMBER)
                                                         .description("추천 피드 마이북 ID"),
                                                 fieldWithPath("data.recommendationFeeds[].bookId").type(NUMBER)


### PR DESCRIPTION
## 🧑‍💻 작업 사항

### 추천 피드, 타겟 soft delete 하지않고, hard delete 하도록 수정
- 추천 피드 생성 -> 삭제 -> 재생성 시,  duplicate key value violates unique constraint 발생
- 마이 리뷰와 같이 soft delete 하지 않고 hard delete 하도록 수정

### 사용자의 추천 피드 조회 응답값 수정
- 사용자의 추천 피드 조회 API 응답값에 해당 도서의 저자 목록 추가

<br><br>

## 🔗 링크

<!-- 관련된 대화가 이루어진 슬랙 링크 혹은 피그마 링크를 첨부. -->
<!-- - [프레이머](https://framer.com/projects/2--gSDcZoNKqU6dqCUQUYQe-53rEr?node=tQMWSSKqy)  -->

<br><br>

## 🐰 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.
<!-- 🚨 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

<br><br>

## 📖 참고 사항

<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.  -->
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->
